### PR TITLE
fix meta.crossplane.io/source annotation

### DIFF
--- a/packages/k8s/crossplane.yaml
+++ b/packages/k8s/crossplane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dot-kubernetes
   annotations:
     meta.crossplane.io/maintainer: Viktor Farcic (@vfarcic)
-    meta.crossplane.io/source: https://github.com/vfarcic/devops-toolkit-crossplane/tree/master/packages/k8s
+    meta.crossplane.io/source: github.com/vfarcic/devops-toolkit-crossplane/tree/master/packages/k8s
     meta.crossplane.io/license: MIT
     meta.crossplane.io/description: Fully operational Kubernetes clusters in AWS (EKS), Google Cloud Platform (GKE), Azure (AKS), and CIVO (CK)
     meta.crossplane.io/readme: A Configuration package that defines a CompositeCluster and ClusterClaim types that can be used to create an provision Kubernetes fully operational clusters in AWS (EKS), Google Cloud Platform (GKE), Azure (AKS), and CIVO (CK)


### PR DESCRIPTION
following page have wrong link to `https//github.com/vfarcic/devops-toolkit-crossplane/tree/master/packages/k8s` (missing `:` after `https` scheme)
https://marketplace.upbound.io/configurations/devops-toolkit/dot-kubernetes/v0.4.24
This may be caused `meta.crossplane.io/source` annotation.
upbound official crossplane.yaml (Especially, I refer to [this](https://github.com/upbound/platform-ref-aws/blob/main/crossplane.yaml#L7)) not including schemes